### PR TITLE
graph classes mentioning other classes

### DIFF
--- a/bin/class-dependencies
+++ b/bin/class-dependencies
@@ -12,7 +12,8 @@ def main
   asts = ARGV.map {|fn| ast_for_filename(fn)}
   cs = CodeExplorer::Consts.new
   cs.report_modules(asts)
-  graph = cs.superclasses
+  #  graph = cs.superclasses
+  graph = cs.mentions
   puts dot_from_hash(graph)
 end
 


### PR DESCRIPTION
RUBYLIB=~/svn/code-explorer/lib \
  ~/svn/code-explorer/bin/class-dependencies \
  `~/svn/code-explorer/bin/required-files ~/svn/ruby-lint/lib ruby-lint` \
  | dotty -

but still report is processed before report/entry. Must really process "require" statements.